### PR TITLE
#19 Add missing URL for nvidia-modprobe archive in info file

### DIFF
--- a/nvidia-bumblebee/nvidia-bumblebee.info
+++ b/nvidia-bumblebee/nvidia-bumblebee.info
@@ -4,11 +4,13 @@ HOMEPAGE="http://www.nvidia.com/"
 DOWNLOAD=" \
   http://download.nvidia.com/XFree86/Linux-x86/$VERSION/NVIDIA-Linux-x86-$VERSION.run \
   http://download.nvidia.com/XFree86/nvidia-settings/nvidia-settings-$VERSION.tar.bz2 \
-  http://download.nvidia.com/XFree86/nvidia-xconfig/nvidia-xconfig-$VERSION.tar.bz2"
+  http://download.nvidia.com/XFree86/nvidia-xconfig/nvidia-xconfig-$VERSION.tar.bz2 \
+	http://download.nvidia.com/XFree86/nvidia-modprobe/nvidia-modprobe-$VERSION.tar.bz2"
 MD5SUM=" \
   f83ef4cc2fae60525ea36c73c706fd00 \
   4bc79fdc003a3f6f48c2d7bec15c5822 \
-  ea1f2011362d82524ccaf6b4b4e0278f"
+  ea1f2011362d82524ccaf6b4b4e0278f \
+	85fe772b3f142978ef1dd06f83bff1a4"
 DOWNLOAD_x86_64="http://download.nvidia.com/XFree86/Linux_x86_64/$VERSION/NVIDIA-Linux-x86_64-$VERSION.run"
 MD5SUM_x86_64="3eb14909ea865690ef563f9c831fc941"
 REQUIRES="bumblebee libvdpau nvidia-kernel"


### PR DESCRIPTION
Adding missing link for nvidia-modprobe in info file for nvidia-bumblebee package.