### PR TITLE
Update nvidia-bumblebee.SlackBuild

### DIFF
--- a/nvidia-bumblebee/nvidia-bumblebee.SlackBuild
+++ b/nvidia-bumblebee/nvidia-bumblebee.SlackBuild
@@ -131,8 +131,6 @@ cd $TMP/${PKGNAM[0]}
     libnvidia-glsi.so.$VERSION \
     libnvidia-opencl.so.$VERSION \
     libnvidia-ptxjitcompiler.so.$VERSION \
-    libGLX_nvidia.so.$VERSION \
-    libEGL_nvidia.so.$VERSION \
    $PKG/usr/lib${LIBDIRSUFFIX}/$PRGNAM
 
   install -m 755 \


### PR DESCRIPTION
Fixes as they are given twice in make command.

install: will not overwrite just-created '/tmp/bbsb/package-nvidia-bumblebee/usr/lib64/nvidia-bumblebee/libGLX_nvidia.so.410.73' with 'libGLX_nvidia.so.410.73'
install: will not overwrite just-created '/tmp/bbsb/package-nvidia-bumblebee/usr/lib64/nvidia-bumblebee/libEGL_nvidia.so.410.73' with 'libEGL_nvidia.so.410.73'