### PR TITLE
nvidia version update + bbswitch patch

### DIFF
--- a/bbswitch/bbswitch.SlackBuild
+++ b/bbswitch/bbswitch.SlackBuild
@@ -62,9 +62,11 @@ set -e
 
 rm -rf $PKG
 mkdir -p $TMP $PKG $OUTPUT
+cp bbswitch.patch $TMP
 cd $TMP
 rm -rf $PRGNAM-$VERSION
 tar xvf $CWD/$PRGNAM-$VERSION.tar.gz
+mv bbswitch.patch $PRGNAM-$VERSION
 cd $PRGNAM-$VERSION
 chown -R root:root .
 find . \
@@ -72,7 +74,7 @@ find . \
  -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 600 -o -perm 444 -o -perm 440 -o -perm 400 \) \
  -exec chmod 644 {} \;
-
+patch < bbswitch.patch
 make KVERSION=$KERNEL KDIR=$KERNELPATH
 
 mkdir -p $PKG/lib/modules/$KERNEL/kernel/drivers/acpi

--- a/bbswitch/bbswitch.patch
+++ b/bbswitch/bbswitch.patch
@@ -1,0 +1,38 @@
+diff -up bbswitch-0.8/bbswitch.c.5.6fix bbswitch-0.8/bbswitch.c
+--- bbswitch-0.8/bbswitch.c.5.6fix      2020-04-27 21:03:31.374417071 -0400
++++ bbswitch-0.8/bbswitch.c     2020-04-28 20:10:56.479080120 -0400
+@@ -35,6 +35,10 @@
+ #include <linux/suspend.h>
+ #include <linux/seq_file.h>
+ #include <linux/pm_runtime.h>
++#include <linux/version.h>
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,6,0)
++#include <linux/proc_fs.h>
++#endif
+ 
+ #define BBSWITCH_VERSION "0.8"
+ 
+@@ -375,6 +379,15 @@ static int bbswitch_pm_handler(struct no
+     return 0;
+ }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,6,0)
++static struct proc_ops bbswitch_fops = {
++    .proc_open   = bbswitch_proc_open,
++    .proc_read   = seq_read,
++    .proc_write  = bbswitch_proc_write,
++    .proc_lseek = seq_lseek,
++    .proc_release= single_release
++};
++#else
+ static struct file_operations bbswitch_fops = {
+     .open   = bbswitch_proc_open,
+     .read   = seq_read,
+@@ -382,6 +395,7 @@ static struct file_operations bbswitch_f
+     .llseek = seq_lseek,
+     .release= single_release
+ };
++#endif
+ 
+ static struct notifier_block nb = {
+     .notifier_call = &bbswitch_pm_handler

--- a/crazybee.sh
+++ b/crazybee.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 ## run as root
 
-# Ryan P. C. McQuen | Everett, WA
+# Ryan P. C. McQuen | Everett, WA | ryanpcmcquen@member.fsf.org
 
 # curl https://raw.githubusercontent.com/ryanpcmcquen/linuxTweaks/master/slackware/crazybee.sh | sh
 

--- a/crazybee.sh
+++ b/crazybee.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 ## run as root
 
-# Ryan P. C. McQuen | Everett, WA | ryanpcmcquen@member.fsf.org
+# Ryan P. C. McQuen | Everett, WA
 
 # curl https://raw.githubusercontent.com/ryanpcmcquen/linuxTweaks/master/slackware/crazybee.sh | sh
 

--- a/nvidia-bumblebee/nvidia-bumblebee.info
+++ b/nvidia-bumblebee/nvidia-bumblebee.info
@@ -1,5 +1,5 @@
 PRGNAM="nvidia-bumblebee"
-VERSION="450.80.02"
+VERSION="455.45.01"
 HOMEPAGE="https://www.nvidia.com/"
 DOWNLOAD=" \
   https://download.nvidia.com/XFree86/nvidia-settings/nvidia-settings-$VERSION.tar.bz2 \

--- a/nvidia-kernel/nvidia-kernel.info
+++ b/nvidia-kernel/nvidia-kernel.info
@@ -1,5 +1,5 @@
 PRGNAM="nvidia-kernel"
-VERSION="450.80.02"
+VERSION="455.45.01"
 HOMEPAGE="https://www.nvidia.com/"
 DOWNLOAD_x86_64="https://download.nvidia.com/XFree86/Linux-x86_64/$VERSION/NVIDIA-Linux-x86_64-$VERSION.run"
 MD5SUM_x86_64="c68b3500fb5ceb17a0fcebcbb143dad8"


### PR DESCRIPTION
This should cover the bbswitch patch and the nvidia version bump so that things work well for kernel 5.10.1