### PR TITLE
.gitignore - rm primus_vk/vk_layer_dispatch_table.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 *.run
 *~
 .??*~
-primus_vk/vk_layer_dispatch_table.h


### PR DESCRIPTION
Hello,
Removed primus_vk/vk_layer_dispatch_table.h from .gitignore

A idea, what you think about rename the folders to the fowling order of install?
libbsd....................-> 1_libbsd
bumblebee.............-> 2_bumblebee
bbswitch................-> 3_bbswitch
primus....................-> 4_primus
primus_vk...............-> 4_primus_vk
nouveau-blacklist....-> 5_nouveau-blacklist
nvidia-kernel...........-> 6_nvidia-kernel
nvidia-bumblebee....-> 7_nvidia-bumblebee

And there is no info about primus_vk in the README.markdown
